### PR TITLE
fix(docker): added network alias for llm-service

### DIFF
--- a/docker-compose-llm-svc.yml
+++ b/docker-compose-llm-svc.yml
@@ -46,7 +46,9 @@ services:
       - DIARIZATION_CONFIG_PATH=${DIARIZATION_CONFIG_PATH}
     restart: unless-stopped
     networks:
-      - astrachat-network
+      astrachat-network:
+        aliases:
+          - llm-service
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/v1/health"]
       interval: 30s


### PR DESCRIPTION
Добавил алиас llm-service для контейнера llm-svc в docker-compose-llm-svc.yml. Это чинит резолв DNS при раздельном запуске бэкенда и LLM-сервиса.